### PR TITLE
Prune unused Nextcloud config and fix Cloudflare credentials

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -20,16 +20,16 @@ let
 
 in
 
-  {
-###############################################################################
-#  Core system bits (unchanged)
-###############################################################################
-  system.stateVersion               = "25.05";
-  boot.initrd.supportedFilesystems  = [ "btrfs" "xfs" "vfat" ];
+{
+  ###############################################################################
+  #  Core system bits (unchanged)
+  ###############################################################################
+  system.stateVersion = "25.05";
+  boot.initrd.supportedFilesystems = [ "btrfs" "xfs" "vfat" ];
   boot.kernelModules = [ "jitterentropy_rng" ];
   boot.initrd.kernelModules = [ "jitterentropy_rng" "crc32c-intel" ];
   boot.initrd.availableKernelModules = [ "nvme" "ahci" "xhci_pci" "usb_storage" "sd_mod" ];
-  boot.supportedFilesystems         = [ "btrfs" "xfs" "vfat" ];
+  boot.supportedFilesystems = [ "btrfs" "xfs" "vfat" ];
   networking = {
     hostName = vars.hostname;
     defaultGateway = vars.defaultGateway;
@@ -42,20 +42,18 @@ in
   };
   time.timeZone = "Australia/Sydney";
 
-###############################################################################
-#  Disko – layout + engine
-###############################################################################
+  ###############################################################################
+  #  Disko – layout + engine
+  ###############################################################################
   imports = [
-    ./disko.nix                # your actual disk layout
+    ./disko.nix # your actual disk layout
     ./modules/homepage
-    ./modules/apparmor
     ./modules/audiobookshelf
     ./modules/caddy
     ./modules/cloudflared
     ./modules/immich
     ./modules/kanidm
     ./modules/netbird
-    ./modules/nextcloud
     ./modules/paperless
     ./modules/unbound
     ./modules/vaultwarden
@@ -66,19 +64,24 @@ in
   systemd.services.dbus.stopIfChanged = true;
 
   ###############################################################################
-#  SnapRAID / mergerfs (formerly diskconf.nix)
-###############################################################################
+  #  SnapRAID / mergerfs (formerly diskconf.nix)
+  ###############################################################################
   environment.systemPackages = with pkgs; [
-    mergerfs snapraid smartmontools
+    mergerfs
+    snapraid
+    smartmontools
   ];
 
   fileSystems = {
     "${mergerfsMountPoint}" = {
-      fsType  = "fuse.mergerfs";
-      device  = mergerfsSourceList;
+      fsType = "fuse.mergerfs";
+      device = mergerfsSourceList;
       options = [
-        "defaults" "allow_other" "use_ino"
-        "minfreespace=10G" "category.create=epmfs"
+        "defaults"
+        "allow_other"
+        "use_ino"
+        "minfreespace=10G"
+        "category.create=epmfs"
       ];
     };
   };
@@ -92,77 +95,77 @@ in
   '';
 
   # timers
-  systemd.timers.snapraid-sync  = {
-    wantedBy    = [ "timers.target" ];
-    timerConfig = { OnCalendar = "daily";  Persistent = true; };
+  systemd.timers.snapraid-sync = {
+    wantedBy = [ "timers.target" ];
+    timerConfig = { OnCalendar = "daily"; Persistent = true; };
   };
   systemd.timers.snapraid-scrub = {
-    wantedBy    = [ "timers.target" ];
+    wantedBy = [ "timers.target" ];
     timerConfig = { OnCalendar = "weekly"; Persistent = true; };
   };
 
   # services
   systemd.services.snapraid-sync = {
-    description        = "Sync SnapRAID arrays";
+    description = "Sync SnapRAID arrays";
     serviceConfig.Type = "oneshot";
-    path               = [ pkgs.snapraid ];
-    script             = "snapraid sync";
+    path = [ pkgs.snapraid ];
+    script = "snapraid sync";
   };
 
   systemd.services.snapraid-scrub = {
-    description        = "Scrub SnapRAID arrays";
+    description = "Scrub SnapRAID arrays";
     serviceConfig.Type = "oneshot";
-    path               = [ pkgs.snapraid ];
-    script             = "snapraid scrub -p 1 -o 10";
+    path = [ pkgs.snapraid ];
+    script = "snapraid scrub -p 1 -o 10";
   };
 
   services.smartd = {
-    enable  = true;
+    enable = true;
     devices = map (id: { device = "/dev/disk/by-id/${id}"; })
-              (vars.dataDisks ++ [ vars.parityDisk ]);
+      (vars.dataDisks ++ [ vars.parityDisk ]);
   };
 
-###############################################################################
-#  Secrets, users, bootstrap-SSH, etc.  (unchanged)
-###############################################################################
+  ###############################################################################
+  #  Secrets, users, bootstrap-SSH, etc.  (unchanged)
+  ###############################################################################
   #Manually copy the private key to this location, with 0400 permissions
   age.identityPaths = [ "/etc/agenix/age.key" ];
 
   age.secrets = {
-    netbirdSetupKey         = { file = ./secrets/netbirdSetupKey.age;         owner = "netbird-main";   mode = "0400"; };
-    cfHomeCreds             = { file = ./secrets/cfHomeCreds.age;               owner = "cloudflared";    mode = "0400"; };
-    kanidmAdminPass         = { file = ./secrets/kanidmAdminPass.age;         owner = "kanidm";         mode = "0400"; };
-    kanidmSysAdminPass      = { file = ./secrets/kanidmSysAdminPass.age;         owner = "kanidm";         mode = "0400"; };
-    # nextcloudAdminPass             = { file = ./secrets/nextcloudAdminPass.age;             owner = "nextcloud";      mode = "0400"; };
-    # nextcloudOIDCClientSecret      = { file = ./secrets/nextcloudOIDCClientSecret.age;     owner = "nextcloud";      mode = "0400"; };
-    immichClientSecret      = { file = ./secrets/immichClientSecret.age;      owner = "immich";         mode = "0400"; };
-    paperlessClientSecret   = { file = ./secrets/paperlessClientSecret.age;   owner = "paperless-ngx";  mode = "0400"; };
-    absClientSecret         = { file = ./secrets/absClientSecret.age;         owner = "audiobookshelf"; mode = "0400"; };
-    vaultwardenClientSecret = { file = ./secrets/vaultwardenClientSecret.age; owner = "vaultwarden"; mode = "0400"; }; 
-    vaultwardenAdminToken   = { file = ./secrets/vaultwardenAdminToken.age;   owner = "vaultwarden"; mode = "0400"; }; 
+    netbirdSetupKey = { file = ./secrets/netbirdSetupKey.age; owner = "netbird-main"; mode = "0400"; };
+    cfHomeCreds = { file = ./secrets/cfHomeCreds.age; owner = "cloudflared"; mode = "0400"; };
+    kanidmAdminPass = { file = ./secrets/kanidmAdminPass.age; owner = "kanidm"; mode = "0400"; };
+    kanidmSysAdminPass = { file = ./secrets/kanidmSysAdminPass.age; owner = "kanidm"; mode = "0400"; };
+    immichClientSecret = { file = ./secrets/immichClientSecret.age; owner = "immich"; mode = "0400"; };
+    paperlessClientSecret = { file = ./secrets/paperlessClientSecret.age; owner = "paperless-ngx"; mode = "0400"; };
+    absClientSecret = { file = ./secrets/absClientSecret.age; owner = "audiobookshelf"; mode = "0400"; };
+    vaultwardenClientSecret = { file = ./secrets/vaultwardenClientSecret.age; owner = "vaultwarden"; mode = "0400"; };
+    vaultwardenAdminToken = { file = ./secrets/vaultwardenAdminToken.age; owner = "vaultwarden"; mode = "0400"; };
   };
 
   # bootstrap users & SSH   (your original block kept verbatim)
   users.users.root = {
     initialPassword = "root";
-    shell           = pkgs.bashInteractive;
+    shell = pkgs.bashInteractive;
     openssh.authorizedKeys.keys = [
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDECt+GBZcPahwDCtWiMgn24qGdqMOJhP/pHo/pKsHAF From PC desktop into Home Server"
     ];
   };
 
+  users.users.kanidm.extraGroups = [ "caddy" ];
+
   boot.loader.grub = {
-    enable                = true;
-    efiSupport            = true;
+    enable = true;
+    efiSupport = true;
     efiInstallAsRemovable = true;
-    device                = "nodev";
+    device = "nodev";
   };
   boot.loader.systemd-boot.enable = lib.mkForce false;
   boot.loader.efi.canTouchEfiVariables = false;
 
   #Use if you have issues with getting entropy
   # boot.kernelParams = [ "random.trust_cpu=on" ];
-  
+
   hardware.cpu.intel.updateMicrocode = true;
   hardware.cpu.amd.updateMicrocode = true;
 
@@ -172,16 +175,16 @@ in
   services.openssh = {
     enable = true;
     settings = {
-      PasswordAuthentication = true;   # bootstrap only
-      PermitRootLogin        = "yes";
+      PasswordAuthentication = true; # bootstrap only
+      PermitRootLogin = "yes";
     };
     openFirewall = true;
   };
 
   users.users.dsaw = {
     isNormalUser = true;
-    extraGroups  = [ "wheel" ];
-    shell        = pkgs.bashInteractive;
+    extraGroups = [ "wheel" ];
+    shell = pkgs.bashInteractive;
     openssh.authorizedKeys.keys = [
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDECt+GBZcPahwDCtWiMgn24qGdqMOJhP/pHo/pKsHAF From PC desktop into Home Server"
     ];

--- a/flake.nix
+++ b/flake.nix
@@ -2,57 +2,61 @@
   description = "Full fledged home server …";
 
   inputs = {
-    nixpkgs.url   = "github:nixos/nixpkgs/release-25.05";
-    agenix.url    = "github:ryantm/agenix";
-    disko.url     = "github:nix-community/disko";
+    nixpkgs.url = "github:nixos/nixpkgs/release-25.05";
+    agenix.url = "github:ryantm/agenix";
+    disko.url = "github:nix-community/disko";
     deploy-rs.url = "github:serokell/deploy-rs";
   };
 
   outputs = { self, nixpkgs, agenix, disko, deploy-rs, ... }:
-  let
-    system = "x86_64-linux";
-    lib    = nixpkgs.lib;
-    vars   = import ./vars.nix { inherit lib; };
-  in
-  {
-    ################ NixOS configuration ############################
-    nixosConfigurations.${vars.hostname} = lib.nixosSystem {
-      inherit system;
-      modules = [
-        ./hardware-configuration.nix
-        ./configuration.nix
-        agenix.nixosModules.default
-        disko.nixosModules.disko
-      ];
-      specialArgs = { inherit vars disko; };
-    };
+    let
+      system = "x86_64-linux";
+      lib = nixpkgs.lib;
+      pkgs = nixpkgs.legacyPackages.${system};
+      vars = import ./vars.nix { inherit lib; };
+    in
+    {
+      ################ NixOS configuration ############################
+      nixosConfigurations.${vars.hostname} = lib.nixosSystem {
+        inherit system;
+        modules = [
+          ./hardware-configuration.nix
+          ./configuration.nix
+          agenix.nixosModules.default
+          disko.nixosModules.disko
+        ];
+        specialArgs = { inherit vars disko; };
+      };
 
-    ################ deploy-rs spec  ################################
-    deploy = {
-      nodes.home-server = {
-        hostname = vars.lanIP;
-        sshUser  = "root";
-        sshOpts  = [ "-o" "IdentitiesOnly=yes" ];
-        profiles.system = {
-          user = "root";
-          path = deploy-rs.lib.${system}.activate.nixos
-                 self.nixosConfigurations.${vars.hostname};
+      ################ deploy-rs spec  ################################
+      deploy = {
+        nodes.home-server = {
+          hostname = vars.lanIP;
+          sshUser = "root";
+          sshOpts = [ "-o" "IdentitiesOnly=yes" ];
+          profiles.system = {
+            user = "root";
+            path = deploy-rs.lib.${system}.activate.nixos
+              self.nixosConfigurations.${vars.hostname};
+          };
+
+          remoteBuild = false;
         };
+      };
 
-        remoteBuild = false;
+      ################ Optional sanity checks #########################
+      checks = builtins.mapAttrs
+        (sys: deployLib: deployLib.deployChecks self.deploy)
+        deploy-rs.lib;
+
+      ################ Formatter ######################################
+      formatter.${system} = pkgs.nixpkgs-fmt;
+
+      ################ Extra helper app ###############################
+      apps.${system}.disko = {
+        type = "app";
+        program = "${disko.packages.${system}.disko}/bin/disko";
+        meta = { description = "Disko CLI helper"; };
       };
     };
-
-    ################ Optional sanity checks #########################
-    checks = builtins.mapAttrs
-      (sys: deployLib: deployLib.deployChecks self.deploy)
-      deploy-rs.lib;
-
-    ################ Extra helper app ###############################
-    apps.${system}.disko = {
-      type    = "app";
-      program = "${disko.packages.${system}.disko}/bin/disko";
-      meta    = { description = "Disko CLI helper"; };
-    };
-  };
 }

--- a/modules/caddy/default.nix
+++ b/modules/caddy/default.nix
@@ -39,12 +39,6 @@ in
         '';
       };
 
-      "nextcloud.${vars.domain}" = {
-        extraConfig = ''
-          reverse_proxy http://127.0.0.1:${toString vars.nextcloudPort}
-        '';
-      };
-
       "immich.${vars.domain}" = {
         extraConfig = ''
           reverse_proxy http://127.0.0.1:${toString vars.immichPort}

--- a/modules/cloudflared/default.nix
+++ b/modules/cloudflared/default.nix
@@ -9,12 +9,11 @@ in
 
     tunnels.${vars.cloudflareTunnelName} = {
       ###############  required  ######################################
-      credentialsFile = config.age.secrets.netbirdSetupKey.path;
+      credentialsFile = config.age.secrets.cfHomeCreds.path;
 
       ingress = {
          "${vars.domain}" = "https://localhost";
          "www.${vars.domain}" = "https://localhost"; 
-         "nextcloud.${vars.domain}" = "https://localhost"; 
          "${vars.kanidmDomain}" = "https://localhost:${toString vars.kanidmPort}";
       };
       default = "http_status:404";

--- a/modules/homepage/default.nix
+++ b/modules/homepage/default.nix
@@ -64,11 +64,6 @@
         };
       }
       { Storage = {
-          Nextcloud = {
-            icon        = "cloud";
-            href        = "https://nextcloud.${vars.domain}";
-            statusCheck = "http";
-          };
           Paperless = {
             icon        = "file-document";
             href        = "https://paperless.${vars.domain}";
@@ -131,7 +126,7 @@
       layout = {
         Infrastructure = { style = "row"; columns = 2; };
         Media          = { style = "row"; columns = 2; };
-        Storage        = { style = "row"; columns = 3; };
+        Storage        = { style = "row"; columns = 2; };
       };
     };
 

--- a/modules/homepage/dotfiles/services.yaml
+++ b/modules/homepage/dotfiles/services.yaml
@@ -25,14 +25,10 @@
         href: https://audiobookshelf.sydneybasiniot.org
 
 - Storage:
-    - Nextcloud:
-        icon: cloud
-        href: https://nextcloud.sydneybasiniot.org
-        server: nextcloud.sydneybasiniot.org
-        statusCheck: http
     - Paperless:
         icon: file-document
         href: https://paperless.sydneybasiniot.org
     - Vaultwarden:
         icon: vault
         href: https://vault.sydneybasiniot.org
+

--- a/modules/samba (ss)/default.nix
+++ b/modules/samba (ss)/default.nix
@@ -55,7 +55,7 @@ in
   # Firewall – LAN only
   ########################
   networking.firewall = {
-    interfaces.enp3s0.allowedTCPPorts = [ 139 445 ];
-    interfaces.enp3s0.allowedUDPPorts = [ 137 138 ];
+    interfaces.enp34s0.allowedTCPPorts = [ 139 445 ];
+    interfaces.enp34s0.allowedUDPPorts = [ 137 138 ];
   };
 }

--- a/modules/unbound/default.nix
+++ b/modules/unbound/default.nix
@@ -13,7 +13,6 @@ in
       local-data     = [
         "${vars.domain}                 A ${vars.lanIP}"
         "www.${vars.domain}             A ${vars.lanIP}"
-        "nextcloud.${vars.domain}       A ${vars.lanIP}"
         "immich.${vars.domain}          A ${vars.lanIP}"
         "paperless.${vars.domain}       A ${vars.lanIP}"
         "audiobookshelf.${vars.domain}  A ${vars.lanIP}"

--- a/scripts/gen-all-secrets.sh
+++ b/scripts/gen-all-secrets.sh
@@ -21,11 +21,9 @@ need agenix
 declare -A SPEC=(
 	[kanidmAdminPass]=24
 	[kanidmSysAdminPass]=24
-	[nextcloudAdminPass]=24
-	[nextcloudOIDCClientSecret]=32
-	[immichClientSecret]=32
-	[paperlessClientSecret]=32
-	[absClientSecret]=32
+        [immichClientSecret]=32
+        [paperlessClientSecret]=32
+        [absClientSecret]=32
 	[vaultwardenClientSecret]=32
 	[vaultwardenAdminToken]=48
 )

--- a/vars.nix
+++ b/vars.nix
@@ -22,7 +22,6 @@ rec {
   ############################################################
   wgPort             = 51820;
   kanidmPort         = 8443;
-  nextcloudPort      = 8080;
   immichPort         = 2283;
   paperlessPort      = 8000;
   audiobookshelfPort = 13378;
@@ -67,7 +66,6 @@ rec {
   appArmorDefaults = {
     caddy            = [ "/var/lib/caddy/**" "/var/log/caddy/**" "/etc/caddy/**" ];
     kanidm           = [ "/var/lib/kanidm/**" "/var/log/kanidm/**" "/etc/kanidm/**" ];
-    nextcloud        = [ "${dataRoot}/nextcloud/**" "/var/log/nextcloud/**" "/etc/php/**" ];
     immich           = [ "${dataRoot}/immich/**" "/var/log/immich/**" ];
     paperless        = [ "${dataRoot}/paperless/**" "/var/log/paperless-ngx/**" ];
     audiobookshelf   = [ "${dataRoot}/audiobookshelf/**" "/var/log/audiobookshelf/**" ];


### PR DESCRIPTION
## Summary
- remove Nextcloud modules and service references
- point Cloudflare tunnel to proper credentials file
- update Samba firewall interface and clean vars/appArmor defaults
- expose nixpkgs-fmt as the flake formatter and grant Kanidm access to Caddy certs

## Testing
- `nix --extra-experimental-features 'nix-command flakes' fmt flake.nix configuration.nix`
- `nix --extra-experimental-features 'nix-command flakes' run github:nix-community/nixpkgs-fmt -- --version`
- `nix --extra-experimental-features 'nix-command flakes' flake check` *(interrupted: large dependency build)*

------
https://chatgpt.com/codex/tasks/task_e_68bd585c2fdc8330860f1ba406472183