### PR TITLE
Align Kanidm TLS cert paths with ACME-managed certificate source

### DIFF
--- a/modules/kanidm/default.nix
+++ b/modules/kanidm/default.nix
@@ -23,9 +23,9 @@
 
       # reuse certificates obtained by Caddy
       tls_chain =
-        "/var/lib/caddy/.local/share/caddy/certificates/acme-v02.api.letsencrypt.org-directory/${vars.kanidmDomain}/${vars.kanidmDomain}.crt";
+        "/var/lib/acme/${vars.kanidmDomain}/fullchain.pem";
       tls_key =
-        "/var/lib/caddy/.local/share/caddy/certificates/acme-v02.api.letsencrypt.org-directory/${vars.kanidmDomain}/${vars.kanidmDomain}.key";
+        "/var/lib/acme/${vars.kanidmDomain}/key.pem";
     };
 
     provision = {


### PR DESCRIPTION
### Motivation
- Use a single ACME certificate source of truth so Kanidm reads the same cert/key files that Caddy provisions under `/var/lib/acme/${vars.kanidmDomain}`. 

### Description
- In `modules/kanidm/default.nix` updated `serverSettings.tls_chain` to `/var/lib/acme/${vars.kanidmDomain}/fullchain.pem` and `tls_key` to `/var/lib/acme/${vars.kanidmDomain}/key.pem`, preserved `systemd.services.kanidm.after`/`wants` including `acme-${vars.kanidmDomain}.service`, and left `users.users.kanidm.extraGroups = [ "caddy" ]` to match the `security.acme.certs."${vars.kanidmDomain}".group` setting. 

### Testing
- Attempted `nix --version` and `nix flake check --no-build` which failed because the `nix` CLI is not available in this environment, and verified repository state with `git status --short` and committed the change with `git commit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7aedd3a9483308d522a901728de1f)