### PR TITLE
Route main cloudflared ingress hosts through Caddy

### DIFF
--- a/modules/cloudflared/default.nix
+++ b/modules/cloudflared/default.nix
@@ -17,9 +17,9 @@
       credentialsFile = config.age.secrets.cfHomeCreds.path;
 
       ingress = {
-        "${vars.domain}" = "http://127.0.0.1:${toString vars.homepagePort}";
-        "www.${vars.domain}" = "http://127.0.0.1:${toString vars.homepagePort}";
-        "${vars.kanidmDomain}" = "https://127.0.0.1:${toString vars.kanidmPort}";
+        "${vars.domain}" = "https://127.0.0.1:443";
+        "www.${vars.domain}" = "https://127.0.0.1:443";
+        "${vars.kanidmDomain}" = "https://127.0.0.1:443";
         "paperless.${vars.domain}" = "http://127.0.0.1:${toString vars.paperlessPort}";
         "immich.${vars.domain}" = "http://127.0.0.1:${toString vars.immichPort}";
         "audiobookshelf.${vars.domain}" = "http://127.0.0.1:${toString vars.audiobookshelfPort}";


### PR DESCRIPTION
### Motivation
- Ensure public hosts are processed by Caddy so TLS, headers, and redirect policy are applied uniformly at the edge instead of some hosts bypassing Caddy via direct Cloudflared-to-backend routing.

### Description
- Updated `modules/cloudflared/default.nix` so `${vars.domain}`, `www.${vars.domain}`, and `${vars.kanidmDomain}` now target `https://127.0.0.1:443` (local Caddy) instead of direct backend ports, while leaving other application ingresses unchanged.

### Testing
- Ran `nl -ba modules/cloudflared/default.nix` and `nl -ba modules/caddy/default.nix` to confirm the cloudflared ingress now points at Caddy and that Caddy config implements `reverse_proxy` for `${vars.domain}` and `${vars.kanidmDomain}` and a single `redir 308` from `www.${vars.domain}`, which matches the intended single-redirect behavior; `git commit` succeeded; attempted `nix --version && nix flake check` failed in this environment with `nix: command not found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7aee84e188330b1fa085d6dbf52ac)